### PR TITLE
chore: add homepage to manifest

### DIFF
--- a/.changeset/silly-penguins-agree.md
+++ b/.changeset/silly-penguins-agree.md
@@ -1,0 +1,6 @@
+---
+"@byteslice/events": patch
+"@byteslice/result": patch
+---
+
+Added project homepage to manifest.

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@byteslice/events",
   "version": "0.4.0",
+  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/events",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ByteSliceHQ/byteslice.git",
+    "directory": "packages/events"
+  },
   "author": {
     "name": "ByteSlice, LLC",
     "url": "https://byteslice.co"

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@byteslice/events",
   "version": "0.4.0",
-  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/events",
+  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/events#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ByteSliceHQ/byteslice.git",

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@byteslice/result",
   "version": "0.2.1",
-  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/result",
+  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/result#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/ByteSliceHQ/byteslice.git",

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@byteslice/result",
   "version": "0.2.1",
+  "homepage": "https://github.com/ByteSliceHQ/byteslice/tree/main/packages/result",
   "repository": {
     "type": "git",
     "url": "https://github.com/ByteSliceHQ/byteslice.git",


### PR DESCRIPTION
Adds [homepage](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#homepage) and [repository](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) sections to each manifest (if not already there).